### PR TITLE
fix: android wear release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3138,6 +3138,33 @@ rnv run -p android
 - none
 
 
+## v0.32.0-feat-androidwear-0 (2021-7-29)
+
+### Fixed
+
+- fix(Android Wear): pick correct bundle file on release build
+- fix(Android Wear): ExtraTranslation error on release build
+- 0.32.0-alpha.44
+- app config merges
+- scoped plugin builds merges
+- [feat] support for plugin root path
+- lint fixes
+- Merge branch 'feat/esbuild_for_hooks' into feat/auto-init-template
+- Merge branch 'feat/packageManager_option' into feat/auto-init-template
+- [feat] auto init project
+- let's see how this goes
+- extra check
+- added packageManager cli option support
+
+### Added Features
+
+- none
+
+### Breaking Changes
+
+- none
+
+  
 ## v0.30.0-rc1 (2020-6-21)
 
 ### Fixed

--- a/docs/changelog/0.32.0-feat-androidwear-0.md
+++ b/docs/changelog/0.32.0-feat-androidwear-0.md
@@ -1,0 +1,27 @@
+## v0.32.0-feat-androidwear-0 (2021-7-29)
+
+### Fixed
+
+- fix(Android Wear): pick correct bundle file on release build
+- fix(Android Wear): ExtraTranslation error on release build
+- 0.32.0-alpha.44
+- app config merges
+- scoped plugin builds merges
+- [feat] support for plugin root path
+- lint fixes
+- Merge branch 'feat/esbuild_for_hooks' into feat/auto-init-template
+- Merge branch 'feat/packageManager_option' into feat/auto-init-template
+- [feat] auto init project
+- let's see how this goes
+- extra check
+- added packageManager cli option support
+
+### Added Features
+
+- none
+
+### Breaking Changes
+
+- none
+
+  

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -2816,7 +2816,7 @@ rnv plugin add recyclerlistview
 ## renative
 
 
-Version: `0.32.0-alpha.43`
+Version: `0.32.0-feat-androidwear-0`
 
 Platforms: `ios`,`android`,`firetv`,`androidtv`,`androidwear`,`web`,`webtv`,`tizen`,`tizenmobile`,`tvos`,`webos`,`macos`,`windows`,`tizenwatch`,`kaios`,`firefoxos`,`firefoxtv`,`chromecast`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "renative-wrapper",
-    "version": "0.32.0-alpha.43",
+    "version": "0.32.0-feat-androidwear-0",
     "currentRelease": "0.31",
     "description": "🚀🚀🚀 Build universal cross-platform apps with React Native. Includes latest `iOS`, `tvOS`, `Android`, `Android TV`, `Fire TV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `Tizen Mobile`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS`, `Firefox TV` and `Chromecast` platforms",
     "keywords": [
@@ -73,7 +73,7 @@
         "git-commit-tag": "cd packages/app && rnv hooks run -x gitCommitAndTag -r",
         "deploy-website": "cd website && yarn && GIT_USER=pavjacko CURRENT_BRANCH=master USE_SSH=true yarn publish-gh-pages",
         "deploy-all": "npm run test && npm run deploy-prepare && npm run deploy-website && npm run git-commit-tag",
-        "deploy:feat": "npm run test && npm run deploy-prepare && npm run git-commit && npx lerna publish from-package --dist-tag feat --yes",
+        "deploy:feat": "npm run test && npm run deploy-prepare && npm run git-commit-tag && npx lerna publish from-package --dist-tag feat --yes && git push origin HEAD",
         "deploy:alpha": "npm run deploy-all && npx lerna publish from-package --dist-tag alpha --yes && git push origin HEAD",
         "deploy:alpha:soft": "npm run test && npm run deploy-prepare && npm run git-commit-tag && npx lerna publish from-package --dist-tag alpha --yes",
         "deploy:prod": "npm run deploy-all && npx lerna publish from-package --yes && git push origin HEAD"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "renative-app",
-    "version": "0.32.0-alpha.43",
+    "version": "0.32.0-feat-androidwear-0",
     "description": "🚀🚀🚀 Build universal cross-platform apps with React Native. Includes latest `iOS`, `tvOS`, `Android`, `Android TV`, `FireTV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `Tizen Mobile`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS` and `Firefox TV` platforms",
     "homepage": "https://github.com/pavjacko/renative#readme",
     "bugs": {

--- a/packages/renative-template-blank/package.json
+++ b/packages/renative-template-blank/package.json
@@ -1,6 +1,6 @@
 {
     "name": "renative-template-blank",
-    "version": "0.32.0-alpha.43",
+    "version": "0.32.0-feat-androidwear-0",
     "description": "🚧 Blank Template for ReNative (https://www.npmjs.com/package/renative). Supports `iOS`, `tvOS`, `Android`, `Android TV`, `FireTV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS`, `Firefox TV`",
     "keywords": [
         "android tv",

--- a/packages/renative-template-hello-world/package.json
+++ b/packages/renative-template-hello-world/package.json
@@ -1,6 +1,6 @@
 {
     "name": "renative-template-hello-world",
-    "version": "0.32.0-alpha.43",
+    "version": "0.32.0-feat-androidwear-0",
     "description": "🚧 Hello World Template for ReNative (https://www.npmjs.com/package/renative). Supports `iOS`, `tvOS`, `Android`, `Android TV`, `FireTV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS`, `Firefox TV`",
     "keywords": [
         "android tv",

--- a/packages/renative-template-kitchen-sink/package.json
+++ b/packages/renative-template-kitchen-sink/package.json
@@ -1,6 +1,6 @@
 {
     "name": "renative-template-kitchen-sink",
-    "version": "0.32.0-alpha.43",
+    "version": "0.32.0-feat-androidwear-0",
     "description": "🚀🚀🚀 Build universal cross-platform apps with React Native. Includes latest `iOS`, `tvOS`, `Android`, `Android TV`, `FireTV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS` and `Firefox TV` platforms",
     "keywords": [
         "android tv",

--- a/packages/renative/package.json
+++ b/packages/renative/package.json
@@ -1,6 +1,6 @@
 {
     "name": "renative",
-    "version": "0.32.0-alpha.43",
+    "version": "0.32.0-feat-androidwear-0",
     "description": "🚀🚀🚀 Build universal cross-platform apps with React Native. Includes latest `iOS`, `tvOS`, `Android`, `Android TV`, `FireTV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS` and `Firefox TV` platforms",
     "keywords": [
         "android tv",

--- a/packages/rnv-engine-lightning/package.json
+++ b/packages/rnv-engine-lightning/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/engine-lightning",
-    "version": "0.32.0-alpha.43",
+    "version": "0.32.0-feat-androidwear-0",
     "description": "ReNative Engine to build lightning based apps.",
     "keywords": [
         "lightning"

--- a/packages/rnv-engine-rn-electron/package.json
+++ b/packages/rnv-engine-rn-electron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/engine-rn-electron",
-    "version": "0.32.0-alpha.43",
+    "version": "0.32.0-feat-androidwear-0",
     "description": "ReNative Engine to build electron based platforms with react native support.",
     "keywords": [
         "electron",

--- a/packages/rnv-engine-rn-next/package.json
+++ b/packages/rnv-engine-rn-next/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/engine-rn-next",
-    "version": "0.32.0-alpha.43",
+    "version": "0.32.0-feat-androidwear-0",
     "description": "ReNative Engine to build next based platforms with react native support.",
     "keywords": [
         "nextjs",

--- a/packages/rnv-engine-rn-web/package.json
+++ b/packages/rnv-engine-rn-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/engine-rn-web",
-    "version": "0.32.0-alpha.43",
+    "version": "0.32.0-feat-androidwear-0",
     "description": "ReNative Engine to build web based platforms with react native support.",
     "keywords": [
         "react-native"

--- a/packages/rnv-engine-rn/package.json
+++ b/packages/rnv-engine-rn/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/engine-rn",
-    "version": "0.32.0-alpha.43",
+    "version": "0.32.0-feat-androidwear-0",
     "description": "ReNative Engine to build react-native based platforms.",
     "keywords": [
         "react-native"

--- a/packages/rnv-engine-rn/src/sdks/sdk-android/kotlinParser.js
+++ b/packages/rnv-engine-rn/src/sdks/sdk-android/kotlinParser.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { FileUtils, Logger, Common } from 'rnv';
+import { Common, FileUtils, Logger } from 'rnv';
 
 const {
     getAppFolder,
@@ -15,7 +15,7 @@ const { logWarning } = Logger;
 const { writeCleanFile } = FileUtils;
 
 const JS_BUNDLE_DEFAULTS = {
-    // CRAPPY BUT Android Wear does not support webview required for connecting to packager
+    // Android Wear does not support webview required for connecting to packager. this is hack to prevent RN connectiing to running bundler
     androidwear: '"assets://index.androidwear.bundle"'
 };
 
@@ -25,7 +25,7 @@ export const parseMainApplicationSync = (c) => {
     const applicationPath = 'app/src/main/java/rnv/MainApplication.kt';
     const bundleAssets = getConfigProp(c, platform, 'bundleAssets');
     const bundleFile = getGetJsBundleFile(c, platform) || bundleAssets
-        ? '"assets://index.android.bundle"'
+        ? `"assets://${getEntryFile(c, platform)}.bundle"`
         : JS_BUNDLE_DEFAULTS[platform] || '"super.getJSBundleFile()"';
     const bundlerIp = getIP() || '10.0.2.2';
     if (!bundleAssets) {

--- a/packages/rnv-engine-rn/templates/platforms/androidwear/app/src/main/res/values-round/strings.xml
+++ b/packages/rnv-engine-rn/templates/platforms/androidwear/app/src/main/res/values-round/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="hello_world">Hello ReNativeRound!</string>
-</resources>

--- a/packages/rnv-engine-rn/templates/platforms/androidwear/app/src/main/res/values/strings.xml
+++ b/packages/rnv-engine-rn/templates/platforms/androidwear/app/src/main/res/values/strings.xml
@@ -1,8 +1,3 @@
 <resources>
     <string name="app_name">{{APP_TITLE}}</string>
-    <!--
-    This string is used for square devices and overridden by hello_world in
-    values-round/strings.xml for round devices.
-    -->
-    <string name="hello_world">Hello ReNativeSquare!</string>
 </resources>

--- a/packages/rnv/coreTemplateFiles/renative.templates.json
+++ b/packages/rnv/coreTemplateFiles/renative.templates.json
@@ -5,23 +5,23 @@
     },
     "engineTemplates": {
         "@rnv/engine-rn": {
-            "version": "0.32.0-alpha.43",
+            "version": "0.32.0-feat-androidwear-0",
             "id": "engine-rn"
         },
         "@rnv/engine-rn-web": {
-            "version": "0.32.0-alpha.43",
+            "version": "0.32.0-feat-androidwear-0",
             "id": "engine-rn-web"
         },
         "@rnv/engine-rn-next": {
-            "version": "0.32.0-alpha.43",
+            "version": "0.32.0-feat-androidwear-0",
             "id": "engine-rn-next"
         },
         "@rnv/engine-rn-electron": {
-            "version": "0.32.0-alpha.43",
+            "version": "0.32.0-feat-androidwear-0",
             "id": "engine-rn-electron"
         },
         "@rnv/engine-lightning": {
-            "version": "0.32.0-alpha.43",
+            "version": "0.32.0-feat-androidwear-0",
             "id": "engine-lightning"
         }
     },

--- a/packages/rnv/package.json
+++ b/packages/rnv/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rnv",
-    "version": "0.32.0-alpha.43",
+    "version": "0.32.0-feat-androidwear-0",
     "description": "💻 CLI for ReNative (https://www.npmjs.com/package/renative). Supports `iOS`, `tvOS`, `Android`, `Android TV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS`, `Firefox TV`",
     "keywords": [
         "android tv",

--- a/packages/rnv/pluginTemplates/renative.plugins.json
+++ b/packages/rnv/pluginTemplates/renative.plugins.json
@@ -20,7 +20,7 @@
             }
         },
         "renative": {
-            "version": "0.32.0-alpha.43",
+            "version": "0.32.0-feat-androidwear-0",
             "webpack": {
                 "modulePaths": [
                     "node_modules/renative"

--- a/website/versioned_docs/version-0.31/changelog.md
+++ b/website/versioned_docs/version-0.31/changelog.md
@@ -3139,6 +3139,33 @@ rnv run -p android
 - none
 
 
+## v0.32.0-feat-androidwear-0 (2021-7-29)
+
+### Fixed
+
+- fix(Android Wear): pick correct bundle file on release build
+- fix(Android Wear): ExtraTranslation error on release build
+- 0.32.0-alpha.44
+- app config merges
+- scoped plugin builds merges
+- [feat] support for plugin root path
+- lint fixes
+- Merge branch 'feat/esbuild_for_hooks' into feat/auto-init-template
+- Merge branch 'feat/packageManager_option' into feat/auto-init-template
+- [feat] auto init project
+- let's see how this goes
+- extra check
+- added packageManager cli option support
+
+### Added Features
+
+- none
+
+### Breaking Changes
+
+- none
+
+  
 ## v0.30.0-rc1 (2020-6-21)
 
 ### Fixed


### PR DESCRIPTION
## Description 

Android Wear builds on release scheme -
```
{
    "signingConfig": "Release",
    "bundleAssets": true,
    "bundleIsDev": false
}
```
were failing because of `ExtraTranslation` error, since xml parser was overriding `values/strings.xml` and deleting `hello_world` string. It was complaining about `values-round/strings.xml`, which after override had no fallback in default locale. 
![image](https://user-images.githubusercontent.com/22332217/127347107-049783c5-60e0-4073-8618-bdf71deb170d.png)
Since this string wasn't used anywhere I simply deleted it.

2nd issue is that if `bundleAssets` was set to `true`, it created `index.androidwear.bundle`, but was looking for `index.android.bundle`. Changed every platform to use corresponding bundle file, which seems to work as I tried all android simulators on both debug and release schemas + installed successfully to android device (contrary to what the comment said), however I'm not sure why was it hardcoded 2 years ago, so please let me know if I missed something.

## Breaking Changes

- PRs should not introduce breaking changes to existing functionality 
- if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    - `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    - `0.[x+1].0` Remove deprecated functionality
    
 ## I have tested my changes on:

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [x] android simulator
* [x] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [x] androidtv simulator
* [ ] androidtv device
* [x] firetv simulator
* [ ] firetv device
* [x] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
