### PR TITLE
fix(icns): When AppIcon.iconset or icns is specified for linux it should be recognized as valid and copied over or generated accordingly

### DIFF
--- a/packages/rnv-engine-rn-electron/src/sdks/sdk-electron/index.js
+++ b/packages/rnv-engine-rn-electron/src/sdks/sdk-electron/index.js
@@ -41,7 +41,8 @@ const {
     copyAssetsFolder
 } = ProjectManager;
 const {
-    MACOS
+    MACOS,
+    LINUX
 } = Constants;
 const { buildCoreWebpackProject, runWebpackServer, configureCoreWebProject, waitForWebpack } = WebpackUtils;
 
@@ -54,16 +55,16 @@ export const configureElectronProject = async (c) => {
     c.runtime.platformBuildsProjectPath = `${getPlatformProjectDir(c)}`;
 
     // If path does not exist for png, try iconset
-    const pngPath = path.join(
+    const iconsetPath = path.join(
         c.paths.appConfig.dir,
-        `assets/${platform}/resources/icon.png`
+        `assets/${platform}/resources/AppIcon.iconset`
     );
 
     await copyAssetsFolder(
         c,
         platform,
         null,
-        platform === MACOS && !pngPath ? _generateICNS : null
+        (platform === MACOS || platform === LINUX) && fsExistsSync(iconsetPath) ? _generateICNS : null
     );
 
     await configureCoreWebProject(c);
@@ -122,7 +123,7 @@ const configureProject = c => new Promise((resolve, reject) => {
         width: 1200,
         height: 800,
         webPreferences: { nodeIntegration: true, enableRemoteModule: true },
-        icon: platform === MACOS && !pngIconPath
+        icon: (platform === MACOS || platform === LINUX) && !fsExistsSync(pngIconPath)
             ? path.join(platformProjectDir, 'resources', 'icon.icns')
             : path.join(platformProjectDir, 'resources', 'icon.png')
     };


### PR DESCRIPTION

## Description 

- Minor fix regarding .icns. Even when .icns was specified ReNative preferred to use .png, which is not correct and this PR aims to fix that

## Breaking Changes

- PRs should not introduce breaking changes to existing functionality 
- if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    - `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    - `0.[x+1].0` Remove deprecated functionality
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
