### PR TITLE
fix(packages): remove non-existing bin paths

### DIFF
--- a/packages/rnv-sdk-apple/package.json
+++ b/packages/rnv-sdk-apple/package.json
@@ -10,9 +10,6 @@
     "license": "MIT",
     "author": "Pavel Jacko <pavel.jacko@gmail.com> (https://github.com/pavjacko)",
     "main": "dist/index.js",
-    "bin": {
-        "sdk-apple": "./dist/cli.js"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renative-org/renative.git"

--- a/packages/rnv-sdk-webpack/package.json
+++ b/packages/rnv-sdk-webpack/package.json
@@ -10,9 +10,6 @@
     "license": "MIT",
     "author": "Pavel Jacko <pavel.jacko@gmail.com> (https://github.com/pavjacko)",
     "main": "dist/index.js",
-    "bin": {
-        "sdk-webpack": "./dist/cli.js"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/renative-org/renative.git"


### PR DESCRIPTION
## Description 

When trying to install `@rnv/sdk-webpack@0.34.0-alpha.8` package on Travis CI,
it throws an error during the installation with the following error message:

```
npm ERR! code ENOENT
246npm ERR! syscall chmod
247npm ERR! path /home/travis/build/ghusername/project/node_modules/@rnv/sdk-webpack/dist/cli.js
248npm ERR! errno -2
249npm ERR! enoent ENOENT: no such file or directory, chmod '/home/travis/build/ghusername/project/node_modules/@rnv/sdk-webpack/dist/cli.js'
250npm ERR! enoent This is related to npm not being able to find a file.
251npm ERR! enoent
```


I noticed that in `@rnv/sdk-webpack`'s `package.json` file, `bin` path points to a non-existing file.
The same issue applies to the `@rnv/sdk-apple` package.

In this PR, `bin` paths are removed for those two packages, as they are not valid.