### PR TITLE
siwtch to gradlePluginPortal instead of jcenter

### DIFF
--- a/packages/rnv-engine-rn-tvos/templates/platforms/androidtv/build.gradle
+++ b/packages/rnv-engine-rn-tvos/templates/platforms/androidtv/build.gradle
@@ -5,9 +5,9 @@ import groovy.json.JsonSlurper
 buildscript {
     ext.kotlin_version = '{{INJECT_KOTLIN_VERSION}}'
     repositories {
-        google()
-        jcenter()
         mavenCentral()
+        google()
+        gradlePluginPortal()
         {{PLUGIN_INJECT_BUILDSCRIPT_REPOSITORIES}}
     }
     dependencies {
@@ -24,10 +24,10 @@ plugins {
 
 allprojects {
     repositories {
-        google()
-        jcenter()
+        maven { url "https://www.jitpack.io" }
         mavenCentral()
-        maven { url "https://jitpack.io" }
+        google()
+        gradlePluginPortal()
         {{INJECT_REACT_NATIVE_ENGINE}}
         {{PLUGIN_INJECT_ALLPROJECTS_REPOSITORIES}}
     }

--- a/packages/rnv-engine-rn-tvos/templates/platforms/firetv/build.gradle
+++ b/packages/rnv-engine-rn-tvos/templates/platforms/firetv/build.gradle
@@ -5,9 +5,9 @@ import groovy.json.JsonSlurper
 buildscript {
     ext.kotlin_version = '{{INJECT_KOTLIN_VERSION}}'
     repositories {
-        google()
-        jcenter()
         mavenCentral()
+        google()
+        gradlePluginPortal()
         {{PLUGIN_INJECT_BUILDSCRIPT_REPOSITORIES}}
     }
     dependencies {
@@ -24,10 +24,10 @@ plugins {
 
 allprojects {
     repositories {
-        google()
-        jcenter()
+        maven { url "https://www.jitpack.io" }
         mavenCentral()
-        maven { url "https://jitpack.io" }
+        google()
+        gradlePluginPortal()
         {{INJECT_REACT_NATIVE_ENGINE}}
         {{PLUGIN_INJECT_ALLPROJECTS_REPOSITORIES}}
     }

--- a/packages/rnv-engine-rn/templates/platforms/android/build.gradle
+++ b/packages/rnv-engine-rn/templates/platforms/android/build.gradle
@@ -6,9 +6,9 @@ buildscript {
     ext.kotlin_version = '{{INJECT_KOTLIN_VERSION}}'
     ext.kotlinVersion = "$kotlin_version"
     repositories {
-        google()
-        jcenter()
         mavenCentral()
+        google()
+        gradlePluginPortal()
         {{PLUGIN_INJECT_BUILDSCRIPT_REPOSITORIES}}
     }
     dependencies {
@@ -25,10 +25,10 @@ plugins {
 
 allprojects {
     repositories {
-        google()
-        jcenter()
+        maven { url "https://www.jitpack.io" }
         mavenCentral()
-        maven { url "https://jitpack.io" }
+        google()
+        gradlePluginPortal()
         {{INJECT_REACT_NATIVE_ENGINE}}
         {{PLUGIN_INJECT_ALLPROJECTS_REPOSITORIES}}
     }

--- a/packages/rnv-engine-rn/templates/platforms/androidtv/build.gradle
+++ b/packages/rnv-engine-rn/templates/platforms/androidtv/build.gradle
@@ -5,9 +5,9 @@ import groovy.json.JsonSlurper
 buildscript {
     ext.kotlin_version = '{{INJECT_KOTLIN_VERSION}}'
     repositories {
-        google()
-        jcenter()
         mavenCentral()
+        google()
+        gradlePluginPortal()
         {{PLUGIN_INJECT_BUILDSCRIPT_REPOSITORIES}}
     }
     dependencies {
@@ -24,10 +24,10 @@ plugins {
 
 allprojects {
     repositories {
-        google()
-        jcenter()
+        maven { url "https://www.jitpack.io" }
         mavenCentral()
-        maven { url "https://jitpack.io" }
+        google()
+        gradlePluginPortal()
         {{INJECT_REACT_NATIVE_ENGINE}}
         {{PLUGIN_INJECT_ALLPROJECTS_REPOSITORIES}}
     }

--- a/packages/rnv-engine-rn/templates/platforms/androidwear/build.gradle
+++ b/packages/rnv-engine-rn/templates/platforms/androidwear/build.gradle
@@ -5,9 +5,9 @@ import groovy.json.JsonSlurper
 buildscript {
     ext.kotlin_version = '{{INJECT_KOTLIN_VERSION}}'
     repositories {
-        google()
-        jcenter()
         mavenCentral()
+        google()
+        gradlePluginPortal()
         {{PLUGIN_INJECT_BUILDSCRIPT_REPOSITORIES}}
     }
     dependencies {
@@ -24,10 +24,10 @@ plugins {
 
 allprojects {
     repositories {
-        google()
-        jcenter()
+        maven { url "https://www.jitpack.io" }
         mavenCentral()
-        maven { url "https://jitpack.io" }
+        google()
+        gradlePluginPortal()
         {{INJECT_REACT_NATIVE_ENGINE}}
         {{PLUGIN_INJECT_ALLPROJECTS_REPOSITORIES}}
     }

--- a/packages/rnv-engine-rn/templates/platforms/firetv/build.gradle
+++ b/packages/rnv-engine-rn/templates/platforms/firetv/build.gradle
@@ -5,9 +5,9 @@ import groovy.json.JsonSlurper
 buildscript {
     ext.kotlin_version = '{{INJECT_KOTLIN_VERSION}}'
     repositories {
-        google()
-        jcenter()
         mavenCentral()
+        google()
+        gradlePluginPortal()
         {{PLUGIN_INJECT_BUILDSCRIPT_REPOSITORIES}}
     }
     dependencies {
@@ -24,10 +24,10 @@ plugins {
 
 allprojects {
     repositories {
-        google()
-        jcenter()
+        maven { url "https://www.jitpack.io" }
         mavenCentral()
-        maven { url "https://jitpack.io" }
+        google()
+        gradlePluginPortal()
         {{INJECT_REACT_NATIVE_ENGINE}}
         {{PLUGIN_INJECT_ALLPROJECTS_REPOSITORIES}}
     }


### PR DESCRIPTION
## Description 

jCenter will shut down on Feb 1, 2022 and currently working very unstable this PR meant to remove jCenter and switch to gradlePluginPortal. Worth to mention that gradlePluginPortal is also mirroring jCenter so that means if jCenter is failing gradlePluginPortal would be failing also, but this was mitigated here https://github.com/gradle/gradle/issues/15406

More info in community:
https://github.com/facebook/react-native/issues/31161

Related issues:
https://github.com/renative-org/renative/issues/783
