### PR TITLE
use metro config abstraction

### DIFF
--- a/packages/rnv/coreTemplateFiles/metro.config.js
+++ b/packages/rnv/coreTemplateFiles/metro.config.js
@@ -1,5 +1,3 @@
-const { withRNV } = require('@rnv/engine-rn');
+const { withRNVMetro } = require('rnv');
 
-const defaultConfig = {};
-
-module.exports = withRNV(defaultConfig);
+module.exports = withRNVMetro({});


### PR DESCRIPTION
Generate abstracted metro config
```
const { withRNVMetro } = require('rnv');

module.exports = withRNVMetro({});
```

instead of 

```
const { withRNV } = require('@rnv/engine-rn');

const defaultConfig = {};

module.exports = withRNV(defaultConfig);

```