### PR TITLE
fix(Android Wear): ExtraTranslation error and incorrect bundle file on release build

### DIFF
--- a/packages/rnv-engine-rn/templates/platforms/androidwear/app/src/main/res/values-round/strings.xml
+++ b/packages/rnv-engine-rn/templates/platforms/androidwear/app/src/main/res/values-round/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="hello_world">Hello ReNativeRound!</string>
-</resources>

--- a/packages/rnv-engine-rn/templates/platforms/androidwear/app/src/main/res/values/strings.xml
+++ b/packages/rnv-engine-rn/templates/platforms/androidwear/app/src/main/res/values/strings.xml
@@ -1,8 +1,3 @@
 <resources>
     <string name="app_name">{{APP_TITLE}}</string>
-    <!--
-    This string is used for square devices and overridden by hello_world in
-    values-round/strings.xml for round devices.
-    -->
-    <string name="hello_world">Hello ReNativeSquare!</string>
 </resources>

--- a/packages/rnv-sdk-android/src/index.ts
+++ b/packages/rnv-sdk-android/src/index.ts
@@ -62,7 +62,8 @@ const { executeAsync, execCLI } = Exec;
 const {
     getAppFolder,
     getConfigProp,
-    getAppId
+    getAppId,
+    getEntryFile
 } = Common;
 const { isPlatformActive, createPlatformBuild } = PlatformManager;
 const { generateEnvVars } = EngineManager;
@@ -86,18 +87,7 @@ const {
     CLI_ANDROID_ADB
 } = Constants;
 
-const _getEntryOutputName = (c: any) => {
-    // CRAPPY BUT Android Wear does not support webview required for connecting to packager. this is hack to prevent RN connectiing to running bundler
-    const { entryFile } = c.buildConfig.platforms[c.platform];
-    // TODO Android PROD Crashes if not using this hardcoded one
-    let outputFile;
-    if (c.platform === ANDROID_WEAR) {
-        outputFile = entryFile;
-    } else {
-        outputFile = 'index.android';
-    }
-    return outputFile;
-};
+
 
 export const packageAndroid = async (c: any) => {
     logTask('packageAndroid');
@@ -110,7 +100,7 @@ export const packageAndroid = async (c: any) => {
         return true;
     }
 
-    const outputFile = _getEntryOutputName(c);
+    const outputFile = getEntryFile(c, platform);
 
     const appFolder = getAppFolder(c);
     let reactNative = c.runtime.runtimeExtraProps?.reactNativePackageName || 'react-native';
@@ -589,7 +579,7 @@ export const configureProject = async (c: any) => {
         return true;
     }
 
-    const outputFile = _getEntryOutputName(c);
+    const outputFile = getEntryFile(c, platform);
 
     mkdirSync(path.join(appFolder, 'app/src/main/assets'));
     fsWriteFileSync(

--- a/packages/rnv-sdk-android/src/kotlinParser.ts
+++ b/packages/rnv-sdk-android/src/kotlinParser.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { FileUtils, Logger, Common } from 'rnv';
+import { Common, FileUtils, Logger } from 'rnv';
 
 const {
     getAppFolder,
@@ -15,7 +15,7 @@ const { logWarning } = Logger;
 const { writeCleanFile } = FileUtils;
 
 const JS_BUNDLE_DEFAULTS: any = {
-    // CRAPPY BUT Android Wear does not support webview required for connecting to packager
+    // Android Wear does not support webview required for connecting to packager. this is hack to prevent RN connectiing to running bundler
     androidwear: '"assets://index.androidwear.bundle"'
 };
 
@@ -26,7 +26,7 @@ export const parseMainApplicationSync = (c: any) => {
     const bundleAssets = getConfigProp(c, platform, 'bundleAssets');
     const bundleDefault = JS_BUNDLE_DEFAULTS[platform];
     const bundleFile: string = getGetJsBundleFile(c, platform) || bundleAssets
-        ? '"assets://index.android.bundle"'
+        ? `"assets://${getEntryFile(c, platform)}.bundle"`
         : bundleDefault || '"super.getJSBundleFile()"';
     const bundlerIp = getIP() || '10.0.2.2';
     if (!bundleAssets) {


### PR DESCRIPTION
## Description 

Reopening old PR (full description - https://github.com/renative-org/renative/pull/700), because it seems like this issue still exists - https://github.com/renative-org/renative/pull/700#issuecomment-1024817587

HOWEVER, I haven't tested these changes recently and the previous closed pr is half a year old. Will try to do that a bit later

## Breaking Changes

- PRs should not introduce breaking changes to existing functionality 
- if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    - `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    - `0.[x+1].0` Remove deprecated functionality
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
