### PR TITLE
fix: missing integration crash

### DIFF
--- a/packages/renative-template-blank/renative.json
+++ b/packages/renative-template-blank/renative.json
@@ -19,10 +19,6 @@
         "platformAssetsDir": "./platformAssets",
         "platformBuildsDir": "./platformBuilds"
     },
-    "integrations": {
-        "@rnv/integration-vercel": "source:rnv",
-        "@rnv/integration-docker": "source:rnv"
-    },
     "tasks": {
         "install": {
             "script": "yarn bootstrap"

--- a/packages/renative-template-hello-world/package.json
+++ b/packages/renative-template-hello-world/package.json
@@ -92,8 +92,6 @@
         "@rnv/engine-rn-tvos": "0.35.2-alpha.1",
         "@rnv/engine-rn-web": "0.35.2-alpha.1",
         "@rnv/engine-rn-windows": "0.35.2-alpha.1",
-        "@rnv/integration-docker": "0.1.0-alpha.1",
-        "@rnv/integration-vercel": "0.2.0-alpha.0",
         "babel-jest": "24.9.0",
         "babel-loader": "8.0.5",
         "cypress": "4.8.0",

--- a/packages/rnv/src/core/integrationManager/index.js
+++ b/packages/rnv/src/core/integrationManager/index.js
@@ -1,20 +1,25 @@
 /* eslint-disable global-require, import/no-dynamic-require */
 
 // import { getScopedVersion } from '../systemManager/utils';
+import { logTask, logWarning } from '../systemManager/logger';
 import { registerCustomTask } from '../taskManager';
 
-
 export const loadIntegrations = async (c) => {
+    logTask('loadIntegrations');
     const integrations = c.buildConfig?.integrations;
 
     if (integrations) {
-        Object.keys(integrations).forEach((k) => {
+        Object.keys(integrations).forEach((integration) => {
             // const ver = getScopedVersion(c, k, integrations[k], 'integrationTemplates');
-            const instance = require(k)?.default;
-            if (instance) {
-                instance.getTasks().forEach((task) => {
-                    registerCustomTask(c, task);
-                });
+            try {
+                const instance = require(integration)?.default;
+                if (instance) {
+                    instance.getTasks().forEach((task) => {
+                        registerCustomTask(c, task);
+                    });
+                }
+            } catch (err) {
+                logWarning(`You have integration ${integration} defined, but it wasn't found in package.json`);
             }
         });
     }


### PR DESCRIPTION
## Description 

- Fixes https://github.com/renative-org/renative/issues/803

## Breaking Changes

- PRs should not introduce breaking changes to existing functionality 
- if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    - `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    - `0.[x+1].0` Remove deprecated functionality
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
