### PR TITLE
fix: run checkSdk before launch, closes #827, closes #829

### DIFF
--- a/packages/rnv/src/engine-core/tasks/task.rnv.target.launch.js
+++ b/packages/rnv/src/engine-core/tasks/task.rnv.target.launch.js
@@ -12,6 +12,7 @@ import { IOS,
     TASK_WORKSPACE_CONFIGURE,
     TASK_TARGET_LAUNCH,
     PARAMS } from '../../core/constants';
+import { checkSdk } from '../../core/sdkManager/installer';
 
 import { launchTizenSimulator } from '../../core/sdkManager/deviceUtils/tizen';
 import { launchWebOSimulator } from '../../core/sdkManager/deviceUtils/webos';
@@ -28,6 +29,8 @@ export const taskRnvTargetLaunch = async (c, parentTask, originTask) => {
 
     const { platform, program } = c;
     const target = program.target || c.files.workspace.config.defaultTargets[platform];
+
+    await checkSdk(c);
 
     switch (platform) {
         case ANDROID:


### PR DESCRIPTION
## Description 

Run `checkSdk` before target launch
