### PR TITLE
fix: use npm if yarn is not installed

### DIFF
--- a/packages/rnv/src/core/projectManager/index.js
+++ b/packages/rnv/src/core/projectManager/index.js
@@ -38,7 +38,7 @@ export const checkAndBootstrapIfRequired = async (c) => {
     logTask('checkAndBootstrapIfRequired');
     const { template } = c.program;
     if (!c.paths.project.configExists && template) {
-        await executeAsync(`${isYarnInstalled ? 'yarn' : 'npm'} add ${template}`, {
+        await executeAsync(`${isYarnInstalled() ? 'yarn' : 'npm'} add ${template}`, {
             cwd: c.paths.project.dir
         });
 

--- a/packages/rnv/src/core/projectManager/index.js
+++ b/packages/rnv/src/core/projectManager/index.js
@@ -25,7 +25,7 @@ import {
     resolvePackage,
     removeDirs,
 } from '../systemManager/fileutils';
-import { installPackageDependencies } from '../systemManager/npmUtils';
+import { installPackageDependencies, isYarnInstalled } from '../systemManager/npmUtils';
 import { executeAsync } from '../systemManager/exec';
 
 import { chalk, logTask, logWarning, logDebug, logInfo, getCurrentCommand } from '../systemManager/logger';
@@ -38,7 +38,7 @@ export const checkAndBootstrapIfRequired = async (c) => {
     logTask('checkAndBootstrapIfRequired');
     const { template } = c.program;
     if (!c.paths.project.configExists && template) {
-        await executeAsync(`npx yarn add ${template}`, {
+        await executeAsync(`${isYarnInstalled ? 'yarn' : 'npm'} add ${template}`, {
             cwd: c.paths.project.dir
         });
 

--- a/packages/rnv/src/core/systemManager/exec.js
+++ b/packages/rnv/src/core/systemManager/exec.js
@@ -537,5 +537,6 @@ export default {
     executeAsync,
     execCLI,
     openCommand,
-    executeTelnet
+    executeTelnet,
+    commandExistsSync
 };

--- a/packages/rnv/src/core/systemManager/npmUtils.js
+++ b/packages/rnv/src/core/systemManager/npmUtils.js
@@ -162,7 +162,7 @@ const _getInstallScript = (c) => {
     }
 };
 
-export const isYarnInstalled = commandExistsSync('yarn') || doResolve('yarn', false);
+export const isYarnInstalled = () => commandExistsSync('yarn') || doResolve('yarn', false);
 
 export const installPackageDependencies = async (c, failOnError = false) => {
     c.runtime.forceBuildHookRebuild = true;
@@ -186,13 +186,13 @@ export const installPackageDependencies = async (c, failOnError = false) => {
 
     if (yarnLockExists || packageLockExists) {
         // a lock file exists, defaulting to whichever is present
-        if (yarnLockExists && !isYarnInstalled) throw new Error('You have a yarn.lock file but you don\'t have yarn installed. Install it or delete yarn.lock');
+        if (yarnLockExists && !isYarnInstalled()) throw new Error('You have a yarn.lock file but you don\'t have yarn installed. Install it or delete yarn.lock');
         command = yarnLockExists ? 'yarn' : 'npm install';
     } else if (c.program.packageManager) {
         // no lock file check cli option
         if (['yarn', 'npm'].includes(c.program.packageManager)) {
             command = c.program.packageManager === 'yarn' ? 'yarn' : 'npm install';
-            if (command === 'yarn' && !isYarnInstalled) throw new Error('You specified yarn as packageManager but it\'s not installed');
+            if (command === 'yarn' && !isYarnInstalled()) throw new Error('You specified yarn as packageManager but it\'s not installed');
         } else {
             throw new Error(`Unsupported package manager ${
                 c.program.packageManager}. Only yarn and npm are supported at the moment.`);

--- a/packages/rnv/src/core/systemManager/npmUtils.js
+++ b/packages/rnv/src/core/systemManager/npmUtils.js
@@ -162,6 +162,8 @@ const _getInstallScript = (c) => {
     }
 };
 
+export const isYarnInstalled = commandExistsSync('yarn') || doResolve('yarn', false);
+
 export const installPackageDependencies = async (c, failOnError = false) => {
     c.runtime.forceBuildHookRebuild = true;
     const customScript = _getInstallScript(c);
@@ -174,7 +176,6 @@ export const installPackageDependencies = async (c, failOnError = false) => {
         return true;
     }
 
-    const isYarnInstalled = commandExistsSync('yarn') || doResolve('yarn', false);
     const yarnLockPath = path.join(c.paths.project.dir, 'yarn.lock');
     const npmLockPath = path.join(c.paths.project.dir, 'package-lock.json');
     let command = 'npm install';

--- a/packages/rnv/src/engine-core/tasks/task.rnv.new.js
+++ b/packages/rnv/src/engine-core/tasks/task.rnv.new.js
@@ -28,7 +28,6 @@ import {
     printIntoBox
 } from '../../core/systemManager/logger';
 import {
-    checkNpxIsInstalled,
     isYarnInstalled,
     listAndSelectNpmVersion
 } from '../../core/systemManager/npmUtils';
@@ -345,9 +344,9 @@ export const taskRnvNew = async (c) => {
     }
 
     data.optionTemplates.selectedVersion = inputTemplateVersion;
-    
+
     await executeAsync(
-        `${isYarnInstalled ? 'yarn' : 'npm'} add ${selectedInputTemplate}@${inputTemplateVersion}`,
+        `${isYarnInstalled() ? 'yarn' : 'npm'} add ${selectedInputTemplate}@${inputTemplateVersion}`,
         {
             cwd: c.paths.project.dir,
         }
@@ -355,7 +354,7 @@ export const taskRnvNew = async (c) => {
 
     // Check if node_modules folder exists
     if (!fsExistsSync(path.join(c.paths.project.dir, 'node_modules'))) {
-        logError(`${isYarnInstalled ? 'yarn' : 'npm'} add ${selectedInputTemplate}@${inputTemplateVersion
+        logError(`${isYarnInstalled() ? 'yarn' : 'npm'} add ${selectedInputTemplate}@${inputTemplateVersion
         } : FAILED. this could happen if you have package.json accidentally created somewhere in parent directory`);
         return;
     }

--- a/packages/rnv/src/engine-core/tasks/task.rnv.new.js
+++ b/packages/rnv/src/engine-core/tasks/task.rnv.new.js
@@ -29,6 +29,7 @@ import {
 } from '../../core/systemManager/logger';
 import {
     checkNpxIsInstalled,
+    isYarnInstalled,
     listAndSelectNpmVersion
 } from '../../core/systemManager/npmUtils';
 
@@ -344,11 +345,9 @@ export const taskRnvNew = async (c) => {
     }
 
     data.optionTemplates.selectedVersion = inputTemplateVersion;
-
-    await checkNpxIsInstalled();
-
+    
     await executeAsync(
-        `npx yarn add ${selectedInputTemplate}@${inputTemplateVersion}`,
+        `${isYarnInstalled ? 'yarn' : 'npm'} add ${selectedInputTemplate}@${inputTemplateVersion}`,
         {
             cwd: c.paths.project.dir,
         }
@@ -356,7 +355,7 @@ export const taskRnvNew = async (c) => {
 
     // Check if node_modules folder exists
     if (!fsExistsSync(path.join(c.paths.project.dir, 'node_modules'))) {
-        logError(`npx yarn add ${selectedInputTemplate}@${inputTemplateVersion
+        logError(`${isYarnInstalled ? 'yarn' : 'npm'} add ${selectedInputTemplate}@${inputTemplateVersion
         } : FAILED. this could happen if you have package.json accidentally created somewhere in parent directory`);
         return;
     }


### PR DESCRIPTION
## Description 

- Don't use yarn if it's not installed
- closes #805 
