### PR TITLE
fix: allow extending sourceExts in metro config

### DIFF
--- a/packages/engine-rn-macos/src/adapter.js
+++ b/packages/engine-rn-macos/src/adapter.js
@@ -45,6 +45,8 @@ export const withRNV = (config) => {
         watchFolders.push(...config.watchFolders);
     }
 
+    const exts = process.env.RNV_EXTENSIONS || '';
+
     const cnf = {
         ...config,
         transformer: {
@@ -72,12 +74,12 @@ export const withRNV = (config) => {
                 /metro.config.local.*/,
             ]),
             ...config?.resolver || {},
+            sourceExts: [...(config?.resolver?.sourceExts || []), ...exts.split(',')],
             extraNodeModules: config?.resolver?.extraNodeModules
         },
         watchFolders,
         projectRoot: path.resolve(projectPath)
     };
-    cnf.resolver.sourceExts = process.env.RNV_EXTENSIONS.split(',');
 
     return cnf;
 };

--- a/packages/engine-rn-tvos/src/adapter.js
+++ b/packages/engine-rn-tvos/src/adapter.js
@@ -51,6 +51,8 @@ export const withRNVMetro = (config) => {
         watchFolders.push(...config.watchFolders);
     }
 
+    const exts = process.env.RNV_EXTENSIONS || '';
+
     const cnf = {
         ...config,
         cacheStores: [
@@ -87,12 +89,12 @@ export const withRNVMetro = (config) => {
                 /metro.config.local.*/,
             ]),
             ...config?.resolver || {},
+            sourceExts: [...(config?.resolver?.sourceExts || []), ...exts.split(',')],
             extraNodeModules: config?.resolver?.extraNodeModules
         },
         watchFolders,
         projectRoot: path.resolve(projectPath)
     };
-    cnf.resolver.sourceExts = process.env.RNV_EXTENSIONS.split(',');
 
     return cnf;
 };

--- a/packages/engine-rn-windows/src/adapter.js
+++ b/packages/engine-rn-windows/src/adapter.js
@@ -50,6 +50,7 @@ export const withRNV = (config) => {
         watchFolders.push(...config.watchFolders);
     }
 
+    const exts = process.env.RNV_EXTENSIONS || '';
 
     const cnf = {
         ...config,
@@ -90,10 +91,9 @@ export const withRNV = (config) => {
             }),
         },
         watchFolders,
+        sourceExts: [...(config?.resolver?.sourceExts || []), ...exts.split(',')],
         projectRoot: path.resolve(projectPath)
     };
-
-    cnf.resolver.sourceExts = process.env.RNV_EXTENSIONS.split(',');
 
     return cnf;
 };

--- a/packages/engine-rn/src/adapter.js
+++ b/packages/engine-rn/src/adapter.js
@@ -44,6 +44,8 @@ export const withRNVMetro = (config) => {
         watchFolders.push(...config.watchFolders);
     }
 
+    const exts = process.env.RNV_EXTENSIONS || '';
+
     const cnf = {
         ...config,
         transformer: {
@@ -73,13 +75,12 @@ export const withRNVMetro = (config) => {
                 /metro.config.local.*/,
             ]),
             ...config?.resolver || {},
+            sourceExts: [...(config?.resolver?.sourceExts || []), ...exts.split(',')],
             extraNodeModules: config?.resolver?.extraNodeModules
         },
         watchFolders,
         projectRoot: path.resolve(projectPath)
     };
-    const exts = process.env.RNV_EXTENSIONS || '';
-    cnf.resolver.sourceExts = exts.split(',');
 
     return cnf;
 };


### PR DESCRIPTION
## Description 

sourceExts were being overriden by rnv, this makes it possible to pass your own values and extend it.

## Breaking Changes

- PRs should not introduce breaking changes to existing functionality 
- if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    - `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    - `0.[x+1].0` Remove deprecated functionality
    
 ## I have tested my changes on:

New project:
 
* [x] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

