### PR TITLE
fix: RNV_EXTERNAL_PATHS stringification, wildcard

### DIFF
--- a/packages/sdk-webpack/src/config/webpack.config.js
+++ b/packages/sdk-webpack/src/config/webpack.config.js
@@ -328,7 +328,7 @@ module.exports = function (webpackEnv) {
                     babelRuntimeEntry,
                     babelRuntimeEntryHelpers,
                     babelRuntimeRegenerator,
-                    ...process.env.RNV_EXTERNAL_PATHS
+                    ...process.env.RNV_EXTERNAL_PATHS.split(',')
                 ]),
             ],
         },

--- a/packages/sdk-webpack/src/index.js
+++ b/packages/sdk-webpack/src/index.js
@@ -153,8 +153,8 @@ export const _runWebDevServer = async (c, enableRemoteDebugger) => {
     process.env.RNV_ENTRY_FILE = getConfigProp(c, c.platform, 'entryFile');
     process.env.PORT = c.runtime.port;
     process.env.RNV_EXTERNAL_PATHS = [
-        path.join(c.paths.project.assets.dir)
-    ];
+        `${path.join(c.paths.project.assets.dir)}/*`
+    ].join(',');
 
     const debugObj = { remoteDebuggerActive: false };
     let debugOrder = [_runRemoteDebuggerChii, _runRemoteDebuggerWeinre];
@@ -182,8 +182,8 @@ export const buildCoreWebpackProject = async (c) => {
     process.env.RNV_ENTRY_FILE = getConfigProp(c, c.platform, 'entryFile');
     process.env.PORT = c.runtime.port;
     process.env.RNV_EXTERNAL_PATHS = [
-        path.join(c.paths.project.assets.dir)
-    ];
+        `${path.join(c.paths.project.assets.dir)}/*`
+    ].join(',');
 
     if (debug) {
         logInfo(


### PR DESCRIPTION

## Description 

["Assigning a property on process.env will implicitly convert the value to a string. This behavior is deprecated. Future versions of Node.js may throw an error when the value is not a string, number, or boolean."](https://nodejs.org/api/process.html#processenv)

The missing ```.split(',')``` causes a string to be spread, resulting in an error as described in #839 when running Tizen or webOS.

However, even with that fixed they still fail to run due to ```ModuleScopePlugin``` blocking them from accessing files outside of ```src/``` (in ```platformAssets/```). It seems like the ```ModuleScopePlugin``` config does not respect directories, but it does respect directories with wildcards (including directories nested within them): ``` `${path.join(c.paths.project.assets.dir)}/*` ```

This PR addresses both issues.



 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [x] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [x] tizen simulator (--hosted)
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [x] webos simulator (--hosted)
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with ~previous~ current version of renative:
 
* [x] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [x] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [x] tizen simulator (--hosted)
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [x] webos simulator (--hosted)
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
