### PR TITLE
fix: resolve webpack router ts and renative sourcemap warnings

### DIFF
--- a/packages/renative/tsconfig.json
+++ b/packages/renative/tsconfig.json
@@ -2,6 +2,8 @@
     "extends": "@flexn/typescript/tsconfig.lib.react.json",
     "compilerOptions": {
         "outDir": "./lib",
-        "rootDir": "./src"
+        "rootDir": "./src",
+        "sourceMap": false,
+        "declarationMap": false,
     }
 }

--- a/packages/template-blank/package.json
+++ b/packages/template-blank/package.json
@@ -66,7 +66,7 @@
         "@rnv/engine-rn-web": "0.36.0-canary.13",
         "@rnv/engine-rn-windows": "0.36.0-canary.13",
         "@rnv/renative": "0.36.0-canary.13",
-        "@types/react": "17.0.41",
+        "@types/react": "18.0.6",
         "@types/react-dom": "17.0.11",
         "@types/react-native": "0.67.2",
         "react": "17.0.2",

--- a/packages/template-blank/renative.template.json
+++ b/packages/template-blank/renative.template.json
@@ -9,7 +9,7 @@
         "packageTemplate": {
             "devDependencies": {
                 "typescript": "4.5.4",
-                "@types/react": "17.0.41",
+                "@types/react": "18.0.6",
                 "@types/react-dom": "17.0.11",
                 "@types/react-native": "0.67.2"
             },

--- a/packages/template-starter/package.json
+++ b/packages/template-starter/package.json
@@ -106,7 +106,7 @@
         "@rnv/engine-rn-windows": "0.36.0-canary.13",
         "@rnv/renative": "0.36.0-canary.13",
         "@rnv/template-starter": "0.36.0-canary.13",
-        "@types/react": "17.0.41",
+        "@types/react": "18.0.6",
         "@types/react-dom": "17.0.11",
         "@types/react-native": "0.67.2",
         "babel-jest": "26.6.3",

--- a/packages/template-starter/renative.template.json
+++ b/packages/template-starter/renative.template.json
@@ -9,7 +9,7 @@
         "packageTemplate": {
             "devDependencies": {
                 "typescript": "4.5.4",
-                "@types/react": "17.0.41",
+                "@types/react": "18.0.6",
                 "@types/react-dom": "17.0.11",
                 "@types/react-native": "0.67.2"
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4963,10 +4963,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@17.0.41":
-  version "17.0.41"
-  resolved "https://registry.npmjs.org/@types/react/-/react-17.0.41.tgz#6e179590d276394de1e357b3f89d05d7d3da8b85"
-  integrity sha512-chYZ9ogWUodyC7VUTRBfblysKLjnohhFY9bGLwvnUFFy48+vB9DikmB3lW0qTFmBcKSzmdglcvkHK71IioOlDA==
+"@types/react@18.0.6":
+  version "18.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.6.tgz#30206c3830af6ce8639b91ace5868bc2d3d1d96c"
+  integrity sha512-bPqwzJRzKtfI0mVYr5R+1o9BOE8UEXefwc1LwcBtfnaAn6OoqMhLa/91VA8aeWfDPJt1kHvYKI8RHcQybZLHHA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
## Description 

Fix webpack warnings
- disable sourcemaps for `renative`
- add correct devDep version for react types

Closes #839 