### PR TITLE
fix: electron support for new webpack 5 configurations

### DIFF
--- a/packages/engine-rn-electron/src/sdks/sdk-electron/index.js
+++ b/packages/engine-rn-electron/src/sdks/sdk-electron/index.js
@@ -55,6 +55,7 @@ export const configureElectronProject = async (c, exitOnFail) => {
     const { platform } = c;
 
     c.runtime.platformBuildsProjectPath = `${getPlatformProjectDir(c)}`;
+    c.runtime.webpackTarget = 'electron-main';
 
     // If path does not exist for png, try iconset
     const iconsetPath = path.join(
@@ -127,7 +128,7 @@ const configureProject = (c, exitOnFail) => new Promise((resolve, reject) => {
     let browserWindow = {
         width: 1200,
         height: 800,
-        webPreferences: { nodeIntegration: true, enableRemoteModule: true },
+        webPreferences: { nodeIntegration: true, enableRemoteModule: true, contextIsolation: false },
         icon: (platform === MACOS || platform === LINUX) && !fsExistsSync(pngIconPath)
             ? path.join(platformProjectDir, 'resources', 'icon.icns')
             : path.join(platformProjectDir, 'resources', 'icon.png')

--- a/packages/sdk-webpack/src/config/webpack.config.js
+++ b/packages/sdk-webpack/src/config/webpack.config.js
@@ -186,7 +186,7 @@ module.exports = function (webpackEnv) {
     };
 
     return {
-        target: ['browserslist'],
+        target: [process.env.WEBPACK_TARGET || 'electron-main'], // browserslist | electron-main ...
         mode: isEnvProduction ? 'production' : isEnvDevelopment && 'development',
         // Stop compilation early in production
         bail: isEnvProduction,

--- a/packages/sdk-webpack/src/index.js
+++ b/packages/sdk-webpack/src/index.js
@@ -152,6 +152,7 @@ export const _runWebDevServer = async (c, enableRemoteDebugger) => {
     process.env.PUBLIC_URL = getConfigProp(c, c.platform, 'publicUrl', '.');
     process.env.RNV_ENTRY_FILE = getConfigProp(c, c.platform, 'entryFile');
     process.env.PORT = c.runtime.port;
+    process.env.WEBPACK_TARGET = c.runtime.webpackTarget;
     process.env.RNV_EXTERNAL_PATHS = [
         `${path.join(c.paths.project.assets.dir)}/*`
     ].join(',');
@@ -181,6 +182,7 @@ export const buildCoreWebpackProject = async (c) => {
     process.env.PUBLIC_URL = getConfigProp(c, c.platform, 'publicUrl', '.');
     process.env.RNV_ENTRY_FILE = getConfigProp(c, c.platform, 'entryFile');
     process.env.PORT = c.runtime.port;
+    process.env.WEBPACK_TARGET = c.runtime.webpackTarget;
     process.env.RNV_EXTERNAL_PATHS = [
         `${path.join(c.paths.project.assets.dir)}/*`
     ].join(',');


### PR DESCRIPTION
## Description 

- Describe the nature of the work / fix

## Breaking Changes

- PRs should not introduce breaking changes to existing functionality 
- if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    - `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    - `0.[x+1].0` Remove deprecated functionality
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
