### PR TITLE
Fix/accept arch xcode build arg

### DIFF
--- a/packages/rnv/src/core/constants.ts
+++ b/packages/rnv/src/core/constants.ts
@@ -439,6 +439,11 @@ export const PARAM_KEYS: any = {
     analyzer: {
         description: 'Enable real-time bundle analyzer'
     },
+    xcodebuildArgs: {
+        value: 'value',
+        isRequired: true,
+        description: 'pass down custom xcodebuild arguments'
+    },
     xcodebuildArchiveArgs: {
         value: 'value',
         isRequired: true,

--- a/packages/sdk-apple/src/index.js
+++ b/packages/sdk-apple/src/index.js
@@ -653,7 +653,8 @@ export const buildXcodeProject = async (c) => {
         p.push('-derivedDataPath');
         p.push(buildPath);
     }
-    if (!ps.includes('-destination')) {
+    // -arch / -sdk params are not compatible with -destination
+    if (!ps.includes('-destination') && !ps.includes('-arch')) {
         p.push('-destination');
         if (platform === MACOS) {
             p.push(`platform=${destinationPlatform}`);


### PR DESCRIPTION
## Description 

- Add xcodebuildArgs (which was already processed but not added) to CLI constants
- Don't provide -destination argument to xcodebuild if -arch is specified in xcodebuildArgs as they are not compatible

    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [x] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
