### PR TITLE
[feat] add support for dynamic plugin fonts

### DIFF
--- a/packages/rnv/src/__tests__/startup.test.ts
+++ b/packages/rnv/src/__tests__/startup.test.ts
@@ -41,7 +41,7 @@ describe('Bootstrapping the CLI', () => {
 
     it('should create C variable correctly', async () => {
         const cKeys = Object.keys(c).sort();
-        const expectKeys = ['api', 'buildConfig', 'cli', 'command', 'configPropsInjects', 'files', 'paths', 'platform', 'process', 'program', 'runtime', 'subCommand'];
+        const expectKeys = ['_renativePluginCache', 'api', 'buildConfig', 'cli', 'command', 'configPropsInjects', 'files', 'paths', 'platform', 'process', 'program', 'runtime', 'subCommand'];
         expect(cKeys).toEqual(expectKeys);
     });
 

--- a/packages/rnv/src/core/configManager/index.js
+++ b/packages/rnv/src/core/configManager/index.js
@@ -697,6 +697,7 @@ export const parseRenativeConfigs = async (c) => {
 
 export const createRnvConfig = (program, process, cmd, subCmd, { projectRoot } = {}) => {
     const c = {
+        _renativePluginCache: {},
         cli: {},
         api: {
             fsExistsSync,

--- a/packages/rnv/src/core/pluginManager/index.js
+++ b/packages/rnv/src/core/pluginManager/index.js
@@ -170,6 +170,10 @@ const _getMergedPlugin = (c, plugin, pluginKey, parentScope, scopes, skipSanitiz
         });
     }
     const mergedObj = mergeObjects(c, parentPlugin, currentPlugin, true, true);
+    if (c._renativePluginCache[pluginKey]) {
+        mergedObj.config = c._renativePluginCache[pluginKey];
+    }
+
     // IMPORTANT: only final top level merge should be sanitized
     const obj = skipSanitize ? mergedObj : sanitizeDynamicProps(mergedObj, {
         files: c.files,
@@ -726,6 +730,10 @@ export const checkForPluginDependencies = async (c) => {
     const toAdd = {};
     Object.keys(c.buildConfig.plugins).forEach((pluginName) => {
         const renativePluginConfig = _getPluginConfiguration(c, pluginName);
+
+        if (renativePluginConfig) {
+            c._renativePluginCache[pluginName] = renativePluginConfig;
+        }
 
         if (renativePluginConfig?.plugins) {
             // we have dependencies for this plugin

--- a/packages/rnv/src/core/projectManager/index.js
+++ b/packages/rnv/src/core/projectManager/index.js
@@ -10,7 +10,7 @@ import {
 import { INJECTABLE_CONFIG_PROPS, RN_BABEL_CONFIG_NAME, RENATIVE_CONFIG_TEMPLATE_NAME } from '../constants';
 import { getEngineRunnerByPlatform } from '../engineManager';
 import { isPlatformActive } from '../platformManager';
-import { copyTemplatePluginsSync } from '../pluginManager';
+import { copyTemplatePluginsSync, parsePlugins } from '../pluginManager';
 import {
     cleanFolder,
     copyFolderContentsRecursiveSync,
@@ -374,15 +374,25 @@ export const parseFonts = (c, callback) => {
                 if (callback) callback(font, c.paths.appConfig.fontsDir);
             });
         }
-        const fontSources = getConfigProp(c, c.platform, 'fontSources', []).map(v => _resolvePackage(c, v));
-        fontSources.forEach((fontSourceDir) => {
-            if (fsExistsSync(fontSourceDir)) {
-                fsReaddirSync(fontSourceDir).forEach((font) => {
-                    if (callback) callback(font, fontSourceDir);
-                });
+        _parseFontSources(c, getConfigProp(c, c.platform, 'fontSources', []), callback);
+        // PLUGIN FONTS
+        parsePlugins(c, c.platform, (plugin) => {
+            if (plugin.config?.fontSources) {
+                _parseFontSources(c, plugin.config?.fontSources, callback);
             }
-        });
+        }, true);
     }
+};
+
+const _parseFontSources = (c, fontSourcesArr, callback) => {
+    const fontSources = fontSourcesArr.map(v => _resolvePackage(c, v));
+    fontSources.forEach((fontSourceDir) => {
+        if (fsExistsSync(fontSourceDir)) {
+            fsReaddirSync(fontSourceDir).forEach((font) => {
+                if (callback) callback(font, fontSourceDir);
+            });
+        }
+    });
 };
 
 const _resolvePackage = (c, v) => {

--- a/packages/rnv/src/engine-core/tasks/task.rnv.project.configure.js
+++ b/packages/rnv/src/engine-core/tasks/task.rnv.project.configure.js
@@ -83,9 +83,9 @@ export const taskRnvProjectConfigure = async (c, parentTask, originTask) => {
         // await configureEntryPoints(c);
         await generateRuntimeConfig(c);
         await overrideTemplatePlugins(c);
-        await configureFonts(c);
         // NOTE: this is needed to ensure missing rnv plugin sub-deps are caught
         await checkForPluginDependencies(c);
+        await configureFonts(c);
     }
 
     return true;


### PR DESCRIPTION
## Description 

- Describe the nature of the work / fix

example in renative.plugin.json

```
"fontSources": [
      "{{resolvePackage(react-native-vector-icons)}}/Fonts",
 ]
```

- PRs should not introduce breaking changes to existing functionality 
- if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    - `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    - `0.[x+1].0` Remove deprecated functionality
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
